### PR TITLE
Shell updates to script.sh

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,16 @@
+#!/usr/bin/env bash
+
+# Logic
+
+## Source profile
+. ~/.profile
+
+## Install NVM modules and set version
 nvm list
 nvm install 8.12.0
 nvm use 8.12.0
 
+## Output Node version used
 node -v
 
 exit 0


### PR DESCRIPTION
I've added some explicit settings to the script to help with debugging. It does the following:

* sets the environment for the script to Bash explicitly
* sources the `.profile` in the user's home
* some comments

It may also be prudent to have it `cat /opt/tsscript/capabilities.md` for debugging but may not be necessary. Depending on how scripts are invoked, if it is not a login shell then it may not source the profile. NVM isn't explicitly dependent on a login shell but if one _isn't_ used then it may cause unexpected [behavior](https://github.com/nvm-sh/nvm/issues/1994).